### PR TITLE
guard for when headers already provide structs

### DIFF
--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -29,6 +29,7 @@
 #include <nfs/rpcv2.h>
 #include <nfs/nfsproto.h>
 #include <nfs/nfs.h>
+#ifndef NFS_NPROCS
 #if (__MAC_OS_X_VERSION_MIN_REQUIRED >= 101406)
 struct nfsstats {
  	uint64_t        attrcache_hits;
@@ -64,6 +65,7 @@ struct nfsstats {
  	uint64_t        pageins;
  	uint64_t        pageouts;
 };
+#endif
 #endif
 #endif
 

--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -29,8 +29,7 @@
 #include <nfs/rpcv2.h>
 #include <nfs/nfsproto.h>
 #include <nfs/nfs.h>
-#ifndef NFS_NPROCS
-#if (__MAC_OS_X_VERSION_MIN_REQUIRED >= 101406)
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000)
 struct nfsstats {
  	uint64_t        attrcache_hits;
  	uint64_t        attrcache_misses;
@@ -65,7 +64,6 @@ struct nfsstats {
  	uint64_t        pageins;
  	uint64_t        pageouts;
 };
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
The macOS toolchain for Xcode 12.4 defines this struct in `nfs.h` if `NFS_NPROCS` is already defined by other includes. By guarding for this we can detect if the struct is already defined and suppress issues building on this toolchain.

Relevant section from `MacOSX10.15.sdk/usr/include/nfs/nfs.h` and consistent in `MacOSX11.1.sdk/usr/include/nfs/nfs.h`:
```
/*
 * XXX to allow amd to include nfs.h without nfsproto.h
 */
#ifdef NFS_NPROCS
/*
 * Stats structure
 */
struct nfsstats {
        uint64_t        attrcache_hits;
```

This structure has been broken apart in newer toolchains as seen in `MacOSX12.1.sdk/usr/include/nfs/nfs.h` and `MacOSX13.1.sdk/usr/include/nfs/nfs.h`:
```
/*
 * XXX to allow amd to include nfs.h without nfsproto.h
 */
#ifdef NFS_NPROCS
/*
 * Stats structure
 */
struct nfsclntstats {
        uint64_t        attrcache_hits;
...
};

struct nfsrvstats {
        uint64_t        srvrpccntv3[NFS_NPROCS];
...
};

#endif
```

Note testing to ensure this struct remains consistent in various headers is likely needed.

Based on the 12.1 header more work may be needed for this to function properly in new OS versions.

A helpful reference repo I came across while looking at header files https://github.com/alexey-lysiuk/macos-sdk