### PR TITLE
Fix a potential negative len value

### DIFF
--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -1028,8 +1028,10 @@ int sigar_proc_env_get(sigar_t *sigar, sigar_pid_t pid,
     }
 
     len = read(fd, buffer, sizeof(buffer));
-
     close(fd);
+    if (len < 0) {
+        return errno;
+    }
 
     buffer[len] = '\0';
     ptr = buffer;


### PR DESCRIPTION
https://man7.org/linux/man-pages/man2/read.2.html

> On error, -1 is returned, and errno is set to indicate the error.
       In this case, it is left unspecified whether the file position
       (if any) changes.